### PR TITLE
Markdown support for <h1> to <h6>

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Title is the first line of the file, followed by 2 empty lines
 
 Specify a different output directory, default is `dist`
 
+#### 🎉 Parse Markdown `#`-like headers from `<h1>` to `<h6>`
+
+Markdown syntax supports HTML headers from `<h1>` to `<h6>` as `#` all the way to `######`, respectively.
+
 ```bash
 $ cargo run -- -i sample.txt --output pages
 ```

--- a/src/cli/generator.rs
+++ b/src/cli/generator.rs
@@ -123,7 +123,7 @@ impl Generator {
         let dest_path = dest_path_prefix.join(format!("{}.html", file.file_stem()));
 
         let mut template = Template::new();
-        template.parse(file.content(), &self.args);
+	template.parse(&file, &self.args);
 
         File::create(&dest_path)
             .and_then(|mut file| file.write_all(template.content().as_bytes()))

--- a/src/file_parser/markdown_parser.rs
+++ b/src/file_parser/markdown_parser.rs
@@ -1,0 +1,197 @@
+pub struct MarkdownDocument<'a> {
+    // the bool refers whether the element is open
+    elements: Vec<(BlockElement<'a>, bool)>
+}
+
+impl <'a> MarkdownDocument<'a> {
+    pub fn new() -> MarkdownDocument<'a> {
+        MarkdownDocument {
+            elements: vec![]
+        }
+    }
+    
+    pub fn add_line_to_document(&mut self, line: &'a str) {
+        let new_element = BlockElement::from(line);
+        
+        if self.elements.len() == 0 && new_element.is_some() {
+            let new_element = new_element.unwrap();
+            if new_element.is_heading() {
+                self.elements.push((new_element, false));
+            } else {
+                self.elements.push((new_element, true));
+            }
+        } else if self.elements.len() != 0 && new_element.is_some() {
+            let new_element = new_element.unwrap();
+            let mut opened_element: Option<&mut (BlockElement<'a>, bool)> = None;
+            
+            for element in self.elements.iter_mut() {
+                if element.1 {  // if element is open
+                    opened_element = Some(element);
+                }
+            }
+            
+            if opened_element.is_some() {
+                let mut opened_element = opened_element.unwrap();
+                if new_element.is_heading() {
+                    opened_element.1 = false;
+                    self.elements.push((new_element, false));
+                } else {
+                    opened_element.0.merge(new_element);
+                }
+            } else {
+                if new_element.is_heading() {
+                    self.elements.push((new_element, false));
+                } else {
+                    self.elements.push((new_element, true));
+                }
+            }
+        } else if self.elements.len() != 0 && new_element.is_none() {
+            for element in self.elements.iter_mut() {
+                if element.1 {  // if element is open
+                    element.1 = false;
+                }
+            }
+        }
+    }
+    pub fn print(&self) -> String {
+        let mut result = String::new();
+        for element in self.elements.iter() {
+            result += element.0.print().as_str();
+        }
+        result
+    }
+}
+
+enum BlockElement<'a> {
+    Heading(usize, Vec<InlineElement<'a>>),
+    Paragraph(Vec<InlineElement<'a>>)
+}
+
+impl <'a> BlockElement<'a> {
+    pub fn from(line: &'a str) -> Option<BlockElement<'a>> {
+        let heading = BlockElement::to_heading(line);
+    
+        if heading.is_some() {
+            return heading;
+        }
+        
+        BlockElement::to_paragraph(line)
+    }
+    
+    fn to_heading(line: &'a str) -> Option<BlockElement<'a>> {
+        let relevant_line_portion = trim_start_at_most(line, ' ', 3);
+        if !relevant_line_portion.starts_with('#') {
+            return None;
+        }
+        
+        let text_after_hashtag_run = trim_start_at_most(relevant_line_portion, '#', 6);
+        
+        if !text_after_hashtag_run.is_empty() &&
+            !text_after_hashtag_run.starts_with(| c: char | c.is_whitespace()) {
+            return None;
+        }
+        
+        let heading_level = relevant_line_portion.len() - text_after_hashtag_run.len();
+        
+        let trailing_whitespace_trimmed_heading = text_after_hashtag_run
+            .trim_start()
+            .trim_end();
+        
+        let trailing_hashtag_trimmed_heading = trailing_whitespace_trimmed_heading.trim_end_matches('#');
+        
+        if !trailing_hashtag_trimmed_heading.is_empty() &&
+            !text_after_hashtag_run.starts_with(| c: char | c.is_whitespace()) {
+                return Some(BlockElement::Heading(
+                    heading_level,
+                    vec![InlineElement::Text(trailing_whitespace_trimmed_heading)]));
+        }
+        
+        Some(BlockElement::Heading(
+            heading_level,
+            vec![InlineElement::Text(trailing_hashtag_trimmed_heading.trim_end())]
+        ))
+    }
+    
+    fn to_paragraph(line: &'a str) -> Option<BlockElement<'a>> {
+        if line.trim().is_empty() {
+            None
+        } else {
+            Some(BlockElement::Paragraph(vec![InlineElement::Text(line.trim())]))
+        }
+    }
+    
+    pub fn merge(&mut self, element: BlockElement<'a>) {
+        if let BlockElement::Paragraph(original_elements) = self {
+            if let BlockElement::Paragraph(mut new_elements) = element {
+                original_elements.push(InlineElement::SoftBreak);
+                original_elements.append(&mut new_elements);
+            }
+        }
+    }
+    
+    pub fn is_heading(&self) -> bool {
+        matches!(*self, BlockElement::Heading(_, _))
+    }
+    
+    pub fn print(&self) -> String {
+        match self {
+            BlockElement::Heading(heading_level, heading_text) => {
+                format!("<h{level}>{inner}</h{level}>",
+                    level = heading_level,
+                    inner = heading_text.iter()
+                        .map(|e| e.print())
+                        .fold(String::new(),
+                        |acc, s| acc + &s))
+            },
+            BlockElement::Paragraph(paragraph_text) => {
+                format!("<p>{}</p>",
+                    paragraph_text.iter()
+                        .map(|e| e.print())
+                        .fold(String::new(),
+                        |acc, s| acc + &s))
+            }
+        }
+    }
+}
+
+enum InlineElement<'a> {
+    Text(&'a str),
+    SoftBreak
+}
+
+impl <'a> InlineElement<'a> {
+    fn print(&self) -> String {
+        match *self {
+            InlineElement::Text(text) => format!("{}", text),
+            InlineElement::SoftBreak => format!(" ")
+        }
+    }
+}
+
+fn trim_start_at_most(line: &str, character_to_skip: char, number_of_times: usize) -> &str {
+    let mut start_index = 0;
+    
+    for (i, c) in line.char_indices() {
+        if start_index == number_of_times || c != character_to_skip {
+            break;
+        }
+        
+        start_index += 1;
+    }
+    
+    &line[start_index..line.len()]
+}
+
+fn trim_end_at_most(line: &str, character_to_skip: char, number_of_times: usize) -> &str {
+    let mut offset_from_end = 0;
+    
+    for (i, c) in line.char_indices().rev() {
+        if offset_from_end == number_of_times || c != character_to_skip {
+            break;
+        }
+        
+        offset_from_end += 1;
+    }
+    
+    &line[0..(line.len() - offset_from_end)]
+}

--- a/src/file_parser/mod.rs
+++ b/src/file_parser/mod.rs
@@ -1,2 +1,3 @@
 pub mod source_file;
 pub mod template_file;
+pub mod markdown_parser;

--- a/src/file_parser/template_file.rs
+++ b/src/file_parser/template_file.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::cli::arg_parser::ArgParser;
+use crate::file_parser::source_file::SourceFile;
 
 pub enum TemplateState {
     PARSED,
@@ -70,8 +71,16 @@ impl Template {
         self.content.as_str()
     }
 
+    pub fn parse(&mut self, source_file: &SourceFile, args: &ArgParser) {
+	if source_file.ext() == "txt" {
+	    self.parse_raw_text(source_file.content(), args);
+	} else if source_file.ext() == "md" {
+	    self.parse_markdown_text(source_file.content(), args);
+	}
+    }
+
     /// Parse the raw content into html content
-    pub fn parse(&mut self, content: &str, args: &ArgParser) {
+    fn parse_raw_text(&mut self, content: &str, args: &ArgParser) {
         let mut body = String::from("");
         let mut title = String::from("");
         let mut blank_line_count = 0;
@@ -103,6 +112,13 @@ impl Template {
         self.set_body(&body);
         self.set_styleshet(parse_stylesheet_url(args.stylesheet()).as_str());
         self.state = TemplateState::PARSED;
+    }
+
+    fn parse_markdown_text(&mut self, content: &str, args: &ArgParser) {
+	let mut body = String::from("");
+	let mut title = String::from("");
+
+	// TODO: Implement the markdown parser
     }
 }
 

--- a/src/file_parser/template_file.rs
+++ b/src/file_parser/template_file.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::cli::arg_parser::ArgParser;
 use crate::file_parser::source_file::SourceFile;
+use crate::file_parser::markdown_parser::MarkdownDocument;
 
 pub enum TemplateState {
     PARSED,
@@ -115,11 +116,24 @@ impl Template {
     }
 
     fn parse_markdown_text(&mut self, content: &str, args: &ArgParser) {
-	let mut body = String::from("");
+	let mut body = parse_markdown_to_html(content);
 	let mut title = String::from("");
 
-	// TODO: Implement the markdown parser
+	self.set_title(&title);
+	self.set_body(&body);
+	self.set_styleshet(parse_stylesheet_url(args.stylesheet()).as_str());
+	self.state = TemplateState::PARSED;
     }
+}
+
+fn parse_markdown_to_html(content: &str) -> String {
+    let mut doc = MarkdownDocument::new();
+
+    for line in content.lines() {
+	doc.add_line_to_document(&line);
+    }
+
+    doc.print()
 }
 
 /// parse the content to suitable html tags


### PR DESCRIPTION
This addresses #24.

One important note: the implementation is based upon the [CommonMarkdown specification, version 0.30](https://spec.commonmark.org/0.30/). Note that I referenced their [parsing strategy](https://spec.commonmark.org/0.30/#appendix-a-parsing-strategy), with some modifications to just focus on the heading feature.

I wanted to implement a Context Free Grammar for Markdown, but I noticed that it might take more time and thinking, and so I decide to go with their strategy.

The reason I went with this strategy and not implement regular expression, is because it is more flexible at the time of implement the emphasis and strong emphasis for the application, since Markdown might be considered a [Context Sensitive Grammar](https://stackoverflow.com/questions/8236422/context-free-grammars-versus-context-sensitive-grammars), regular expressions might not be suitable, since they are used for [regular languages](https://en.wikipedia.org/wiki/Regular_language). This means that regular expressions are not as powerful to create complete Markdown parsers.

Either way, there a lot of room for improvements:
* improve the internal API for the `MarkdownParser`: since the `MarkdownParser` has a simple public API, changes within the parser are doable without the need of a lot of refactoring outside of the `markdown_parser` module.
* fix some bugs regarding escaping characters: Markdown specifies escaping for characters that hold special meaning. The current parser does not handle them correctly.
* add the rest of the features, and even more: if the internal API is improved, adding more features such as emphasis and strong emphasis will not require a lot of effort.

I suggest we keep the lifetime `'a` parameter for the structures, since they help us avoiding a lot of copy when parsing the files. Technically, copying of the input strings only happens when printing!